### PR TITLE
Also use buffer_compat of node-png for node-jpeg

### DIFF
--- a/src/buffer_compat.cpp
+++ b/src/buffer_compat.cpp
@@ -1,0 +1,58 @@
+#include <node.h>
+#include <node_buffer.h>
+#include <node_version.h>
+#include <v8.h>
+#include "buffer_compat.h"
+
+
+#if NODE_MINOR_VERSION < 3
+
+
+char *BufferData(node::Buffer *b) {
+  return b->data();
+}
+
+
+size_t BufferLength(node::Buffer *b) {
+  return b->length();
+}
+
+
+char *BufferData(v8::Local<v8::Object> buf_obj) {
+  v8::HandleScope scope;
+  node::Buffer *buf = node::ObjectWrap::Unwrap<node::Buffer>(buf_obj);
+  return buf->data();
+}
+
+
+size_t BufferLength(v8::Local<v8::Object> buf_obj) {
+  v8::HandleScope scope;
+  node::Buffer *buf = node::ObjectWrap::Unwrap<node::Buffer>(buf_obj);
+  return buf->length();
+}
+
+#else // NODE_VERSION
+
+
+char *BufferData(node::Buffer *b) {
+  return node::Buffer::Data(b->handle_);
+}
+
+
+size_t BufferLength(node::Buffer *b) {
+  return node::Buffer::Length(b->handle_);
+}
+
+
+char *BufferData(v8::Local<v8::Object> buf_obj) {
+  v8::HandleScope scope;
+  return node::Buffer::Data(buf_obj);
+}
+
+
+size_t BufferLength(v8::Local<v8::Object> buf_obj) {
+  v8::HandleScope scope;
+  return node::Buffer::Length(buf_obj);
+}
+
+#endif // NODE_VERSION

--- a/src/buffer_compat.h
+++ b/src/buffer_compat.h
@@ -1,0 +1,15 @@
+#ifndef buffer_compat_h
+#define buffer_compat_h
+
+#include <node.h>
+#include <node_buffer.h>
+#include <v8.h>
+
+char *BufferData(node::Buffer *b);
+size_t BufferLength(node::Buffer *b);
+
+char *BufferData(v8::Local<v8::Object> buf_obj);
+size_t BufferLength(v8::Local<v8::Object> buf_obj);
+
+
+#endif  // buffer_compat_h

--- a/src/dynamic_jpeg_stack.cpp
+++ b/src/dynamic_jpeg_stack.cpp
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "dynamic_jpeg_stack.h"
 #include "jpeg_encoder.h"
+#include "buffer_compat.h"
 
 using namespace v8;
 using namespace node;
@@ -71,7 +72,7 @@ DynamicJpegStack::JpegEncodeSync()
         jpeg_encoder.encode();
         int jpeg_len = jpeg_encoder.get_jpeg_len();
         Buffer *retbuf = Buffer::New(jpeg_len);
-        memcpy(retbuf->data(), jpeg_encoder.get_jpeg(), jpeg_len);
+        memcpy(BufferData(retbuf), jpeg_encoder.get_jpeg(), jpeg_len);
         return scope.Close(retbuf->handle_); 
     }
     catch (const char *err) {
@@ -294,7 +295,7 @@ DynamicJpegStack::Push(const Arguments &args)
     if (y+h > jpeg->bg_height) 
         return VException("Pushed fragment exceeds DynamicJpegStack's height.");
 
-    jpeg->Push((unsigned char *)data_buf->data(), x, y, w, h);
+    jpeg->Push((unsigned char *)BufferData(data_buf), x, y, w, h);
 
     return Undefined();
 }
@@ -324,7 +325,7 @@ DynamicJpegStack::SetBackground(const Arguments &args)
         return VException("Coordinate y smaller than 0.");
 
     try {
-        jpeg->SetBackground((unsigned char *)data_buf->data(), w, h);
+        jpeg->SetBackground((unsigned char *)BufferData(data_buf), w, h);
     }
     catch (const char *err) {
         return VException(err);
@@ -422,7 +423,7 @@ DynamicJpegStack::EIO_JpegEncodeAfter(eio_req *req)
     }
     else {
         Buffer *buf = Buffer::New(enc_req->jpeg_len);
-        memcpy(buf->data(), enc_req->jpeg, enc_req->jpeg_len);
+        memcpy(BufferData(buf), enc_req->jpeg, enc_req->jpeg_len);
         argv[0] = buf->handle_;
         argv[1] = jpeg->Dimensions();
         argv[2] = Undefined();

--- a/src/fixed_jpeg_stack.cpp
+++ b/src/fixed_jpeg_stack.cpp
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "fixed_jpeg_stack.h"
 #include "jpeg_encoder.h"
+#include "buffer_compat.h"
 
 using namespace v8;
 using namespace node;
@@ -42,7 +43,7 @@ FixedJpegStack::JpegEncodeSync()
         jpeg_encoder.encode();
         int jpeg_len = jpeg_encoder.get_jpeg_len();
         Buffer *retbuf = Buffer::New(jpeg_len);
-        memcpy(retbuf->data(), jpeg_encoder.get_jpeg(), jpeg_len);
+        memcpy(BufferData(retbuf), jpeg_encoder.get_jpeg(), jpeg_len);
         return scope.Close(retbuf->handle_); 
     }
     catch (const char *err) {
@@ -217,7 +218,7 @@ FixedJpegStack::Push(const Arguments &args)
     if (y+h > jpeg->height) 
         return VException("Pushed fragment exceeds FixedJpegStack's height.");
 
-    jpeg->Push((unsigned char *)data_buf->data(), x, y, w, h);
+    jpeg->Push((unsigned char *)BufferData(data_buf), x, y, w, h);
 
     return Undefined();
 }
@@ -288,7 +289,7 @@ FixedJpegStack::EIO_JpegEncodeAfter(eio_req *req)
     }
     else {
         Buffer *buf = Buffer::New(enc_req->jpeg_len);
-        memcpy(buf->data(), enc_req->jpeg, enc_req->jpeg_len);
+        memcpy(BufferData(buf), enc_req->jpeg, enc_req->jpeg_len);
         argv[0] = buf->handle_;
         argv[1] = Undefined();
     }

--- a/src/jpeg.cpp
+++ b/src/jpeg.cpp
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "jpeg.h"
 #include "jpeg_encoder.h"
+#include "buffer_compat.h"
 
 using namespace v8;
 using namespace node;
@@ -25,7 +26,7 @@ Jpeg::Initialize(v8::Handle<v8::Object> target)
 }
 
 Jpeg::Jpeg(Buffer *ddata, int wwidth, int hheight, buffer_type bbuf_type) :
-    jpeg_encoder((unsigned char *)ddata->data(), wwidth, hheight, 60, bbuf_type) {}
+    jpeg_encoder((unsigned char *)BufferData(ddata), wwidth, hheight, 60, bbuf_type) {}
 
 Handle<Value>
 Jpeg::JpegEncodeSync()
@@ -41,7 +42,7 @@ Jpeg::JpegEncodeSync()
 
     int jpeg_len = jpeg_encoder.get_jpeg_len();
     Buffer *retbuf = Buffer::New(jpeg_len);
-    memcpy(retbuf->data(), jpeg_encoder.get_jpeg(), jpeg_len);
+    memcpy(BufferData(retbuf), jpeg_encoder.get_jpeg(), jpeg_len);
     return scope.Close(retbuf->handle_); 
 }
 
@@ -177,7 +178,7 @@ Jpeg::EIO_JpegEncodeAfter(eio_req *req)
     }
     else {
         Buffer *buf = Buffer::New(enc_req->jpeg_len);
-        memcpy(buf->data(), enc_req->jpeg, enc_req->jpeg_len);
+        memcpy(BufferData(buf), enc_req->jpeg, enc_req->jpeg_len);
         argv[0] = buf->handle_;
         argv[1] = Undefined();
     }


### PR DESCRIPTION
I just integrated the buffer_compat helpers you used in node-png into the node-jpeg module to make it usable in nodejs >=0.3

couldn't test it but it compiles well. maybe you have some automated tests you could run against the code with node 0.3 or 0.4.

thanks!
