### PR TITLE
function signature of libeio's `eio_custom` has changed - build fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
    "name": "jpeg",
    "version": "1.0.0",
-   "main": "jpeg",
+   "main": "build/Release/jpeg",
    "description": "A C++ module for node-js that converts RGB and RGBA buffers to a JPEG images (in memory).",
    "keywords": [
        "jpg",

--- a/src/dynamic_jpeg_stack.cpp
+++ b/src/dynamic_jpeg_stack.cpp
@@ -377,7 +377,7 @@ DynamicJpegStack::SetQuality(const Arguments &args)
     return Undefined();
 }
 
-int
+void
 DynamicJpegStack::EIO_JpegEncode(eio_req *req)
 {
     encode_request *enc_req = (encode_request *)req->data;
@@ -392,7 +392,7 @@ DynamicJpegStack::EIO_JpegEncode(eio_req *req)
         enc_req->jpeg = (char *)malloc(sizeof(*enc_req->jpeg)*enc_req->jpeg_len);
         if (!enc_req->jpeg) {
             enc_req->error = strdup("malloc in DynamicJpegStack::EIO_JpegEncode failed.");
-            return 0;
+            return;
         }
         else {
             memcpy(enc_req->jpeg, encoder.get_jpeg(), enc_req->jpeg_len);
@@ -401,8 +401,6 @@ DynamicJpegStack::EIO_JpegEncode(eio_req *req)
     catch (const char *err) {
         enc_req->error = strdup(err);
     }
-
-    return 0;
 }
 
 int 

--- a/src/dynamic_jpeg_stack.h
+++ b/src/dynamic_jpeg_stack.h
@@ -21,7 +21,7 @@ class DynamicJpegStack : public node::ObjectWrap {
 
     void update_optimal_dimension(int x, int y, int w, int h);
 
-    static int EIO_JpegEncode(eio_req *req);
+    static void EIO_JpegEncode(eio_req *req);
     static int EIO_JpegEncodeAfter(eio_req *req);
 public:
     DynamicJpegStack(buffer_type bbuf_type);

--- a/src/fixed_jpeg_stack.cpp
+++ b/src/fixed_jpeg_stack.cpp
@@ -247,7 +247,7 @@ FixedJpegStack::SetQuality(const Arguments &args)
     return Undefined();
 }
 
-int
+void
 FixedJpegStack::EIO_JpegEncode(eio_req *req)
 {
     encode_request *enc_req = (encode_request *)req->data;
@@ -260,7 +260,7 @@ FixedJpegStack::EIO_JpegEncode(eio_req *req)
         enc_req->jpeg = (char *)malloc(sizeof(*enc_req->jpeg)*enc_req->jpeg_len);
         if (!enc_req->jpeg) {
             enc_req->error = strdup("malloc in FixedJpegStack::EIO_JpegEncode failed.");
-            return 0;
+            return;
         }
         else {
             memcpy(enc_req->jpeg, encoder.get_jpeg(), enc_req->jpeg_len);
@@ -269,8 +269,6 @@ FixedJpegStack::EIO_JpegEncode(eio_req *req)
     catch (const char *err) {
         enc_req->error = strdup(err);
     }
-
-    return 0;
 }
 
 int 

--- a/src/fixed_jpeg_stack.h
+++ b/src/fixed_jpeg_stack.h
@@ -13,7 +13,7 @@ class FixedJpegStack : public node::ObjectWrap {
 
     unsigned char *data;
 
-    static int EIO_JpegEncode(eio_req *req);
+    static void EIO_JpegEncode(eio_req *req);
     static int EIO_JpegEncodeAfter(eio_req *req);
 
 public:

--- a/src/jpeg.cpp
+++ b/src/jpeg.cpp
@@ -26,7 +26,7 @@ Jpeg::Initialize(v8::Handle<v8::Object> target)
 }
 
 Jpeg::Jpeg(Buffer *ddata, int wwidth, int hheight, buffer_type bbuf_type) :
-    jpeg_encoder((unsigned char *)BufferData(ddata), wwidth, hheight, 60, bbuf_type) {}
+    jpeg_encoder((unsigned char *)Buffer::Data(ddata), wwidth, hheight, 60, bbuf_type) {}
 
 Handle<Value>
 Jpeg::JpegEncodeSync()
@@ -42,7 +42,7 @@ Jpeg::JpegEncodeSync()
 
     int jpeg_len = jpeg_encoder.get_jpeg_len();
     Buffer *retbuf = Buffer::New(jpeg_len);
-    memcpy(BufferData(retbuf), jpeg_encoder.get_jpeg(), jpeg_len);
+    memcpy(Buffer::Data(retbuf), jpeg_encoder.get_jpeg(), jpeg_len);
     return scope.Close(retbuf->handle_); 
 }
 
@@ -176,7 +176,7 @@ Jpeg::EIO_JpegEncodeAfter(eio_req *req)
     }
     else {
         Buffer *buf = Buffer::New(enc_req->jpeg_len);
-        memcpy(BufferData(buf), enc_req->jpeg, enc_req->jpeg_len);
+        memcpy(Buffer::Data(buf), enc_req->jpeg, enc_req->jpeg_len);
         argv[0] = buf->handle_;
         argv[1] = Undefined();
     }

--- a/src/jpeg.cpp
+++ b/src/jpeg.cpp
@@ -137,7 +137,7 @@ Jpeg::SetQuality(const Arguments &args)
     return Undefined();
 }
 
-int
+void
 Jpeg::EIO_JpegEncode(eio_req *req)
 {
     encode_request *enc_req = (encode_request *)req->data;
@@ -149,7 +149,7 @@ Jpeg::EIO_JpegEncode(eio_req *req)
         enc_req->jpeg = (char *)malloc(sizeof(*enc_req->jpeg)*enc_req->jpeg_len);
         if (!enc_req->jpeg) {
             enc_req->error = strdup("malloc in Jpeg::EIO_JpegEncode failed.");
-            return 0;
+            return;
         }
         else {
             memcpy(enc_req->jpeg, jpeg->jpeg_encoder.get_jpeg(), enc_req->jpeg_len);
@@ -158,8 +158,6 @@ Jpeg::EIO_JpegEncode(eio_req *req)
     catch (const char *err) {
         enc_req->error = strdup(err);
     }
-
-    return 0;
 }
 
 int 

--- a/src/jpeg.cpp
+++ b/src/jpeg.cpp
@@ -25,8 +25,8 @@ Jpeg::Initialize(v8::Handle<v8::Object> target)
     target->Set(String::NewSymbol("Jpeg"), t->GetFunction());
 }
 
-Jpeg::Jpeg(Buffer *ddata, int wwidth, int hheight, buffer_type bbuf_type) :
-    jpeg_encoder((unsigned char *)Buffer::Data(ddata), wwidth, hheight, 60, bbuf_type) {}
+Jpeg::Jpeg(unsigned char *ddata, int wwidth, int hheight, buffer_type bbuf_type) :
+    jpeg_encoder(ddata, wwidth, hheight, 60, bbuf_type) {}
 
 Handle<Value>
 Jpeg::JpegEncodeSync()
@@ -98,8 +98,8 @@ Jpeg::New(const Arguments &args)
             return VException("Buffer type wasn't 'rgb', 'bgr', 'rgba' or 'bgra'.");
     }
 
-    Buffer *data_buf = ObjectWrap::Unwrap<Buffer>(args[0]->ToObject());
-    Jpeg *jpeg = new Jpeg(data_buf, w, h, buf_type);
+    Local<Object> jpeg = args[0]->ToObject();
+    Jpeg *jpeg = new Jpeg(Buffer::Data(jpeg), w, h, buf_type);
     jpeg->Wrap(args.This());
     return args.This();
 }

--- a/src/jpeg.cpp
+++ b/src/jpeg.cpp
@@ -98,8 +98,8 @@ Jpeg::New(const Arguments &args)
             return VException("Buffer type wasn't 'rgb', 'bgr', 'rgba' or 'bgra'.");
     }
 
-    Local<Object> jpeg = args[0]->ToObject();
-    Jpeg *jpeg = new Jpeg(Buffer::Data(jpeg), w, h, buf_type);
+    Local<Object> buffer = args[0]->ToObject();
+    Jpeg *jpeg = new Jpeg(Buffer::Data(buffer), w, h, buf_type);
     jpeg->Wrap(args.This());
     return args.This();
 }

--- a/src/jpeg.cpp
+++ b/src/jpeg.cpp
@@ -99,7 +99,7 @@ Jpeg::New(const Arguments &args)
     }
 
     Local<Object> buffer = args[0]->ToObject();
-    Jpeg *jpeg = new Jpeg(Buffer::Data(buffer), w, h, buf_type);
+    Jpeg *jpeg = new Jpeg((unsigned char*) Buffer::Data(buffer), w, h, buf_type);
     jpeg->Wrap(args.This());
     return args.This();
 }

--- a/src/jpeg.h
+++ b/src/jpeg.h
@@ -13,7 +13,7 @@ class Jpeg : public node::ObjectWrap {
     static int EIO_JpegEncodeAfter(eio_req *req);
 public:
     static void Initialize(v8::Handle<v8::Object> target);
-    Jpeg(node::Buffer *ddata, int wwidth, int hheight, buffer_type bbuf_type);
+    Jpeg(unsigned char *ddata, int wwidth, int hheight, buffer_type bbuf_type);
     v8::Handle<v8::Value> JpegEncodeSync();
     void SetQuality(int q);
 

--- a/src/jpeg.h
+++ b/src/jpeg.h
@@ -9,7 +9,7 @@
 class Jpeg : public node::ObjectWrap {
     JpegEncoder jpeg_encoder;
 
-    static int EIO_JpegEncode(eio_req *req);
+    static void EIO_JpegEncode(eio_req *req);
     static int EIO_JpegEncodeAfter(eio_req *req);
 public:
     static void Initialize(v8::Handle<v8::Object> target);


### PR DESCRIPTION
the first argument of `eio_custom` is no longer an `int (*)(eio_req*)` but a `void (*)(eio_req*)`.

see this commit comment for the change upstream:
https://github.com/joyent/node/commit/88afc406caa64628a249d726659b3b054f8dc70d#commitcomment-580709
