### PR TITLE
made examples for dynamic and fixed jpeg stack run again under node 6.2

### DIFF
--- a/src/dynamic_jpeg_stack.cpp
+++ b/src/dynamic_jpeg_stack.cpp
@@ -272,7 +272,7 @@ DynamicJpegStack::Push(const Arguments &args)
     if (!jpeg->data)
         return VException("No background has been set, use setBackground or setSolidBackground to set.");
 
-    Buffer *data_buf = ObjectWrap::Unwrap<Buffer>(args[0]->ToObject());
+    Local<Object> data_buf = args[0]->ToObject();
     int x = args[1]->Int32Value();
     int y = args[2]->Int32Value();
     int w = args[3]->Int32Value();
@@ -315,7 +315,7 @@ DynamicJpegStack::SetBackground(const Arguments &args)
         return VException("Third argument must be integer height.");
 
     DynamicJpegStack *jpeg = ObjectWrap::Unwrap<DynamicJpegStack>(args.This());
-    Buffer *data_buf = ObjectWrap::Unwrap<Buffer>(args[0]->ToObject());
+    Local<Object> data_buf = args[0]->ToObject();
     int w = args[1]->Int32Value();
     int h = args[2]->Int32Value();
 

--- a/src/dynamic_jpeg_stack.cpp
+++ b/src/dynamic_jpeg_stack.cpp
@@ -72,7 +72,7 @@ DynamicJpegStack::JpegEncodeSync()
         jpeg_encoder.encode();
         int jpeg_len = jpeg_encoder.get_jpeg_len();
         Buffer *retbuf = Buffer::New(jpeg_len);
-        memcpy(BufferData(retbuf), jpeg_encoder.get_jpeg(), jpeg_len);
+        memcpy(Buffer::Data(retbuf), jpeg_encoder.get_jpeg(), jpeg_len);
         return scope.Close(retbuf->handle_); 
     }
     catch (const char *err) {
@@ -295,7 +295,7 @@ DynamicJpegStack::Push(const Arguments &args)
     if (y+h > jpeg->bg_height) 
         return VException("Pushed fragment exceeds DynamicJpegStack's height.");
 
-    jpeg->Push((unsigned char *)BufferData(data_buf), x, y, w, h);
+    jpeg->Push((unsigned char *)Buffer::Data(data_buf), x, y, w, h);
 
     return Undefined();
 }
@@ -325,7 +325,7 @@ DynamicJpegStack::SetBackground(const Arguments &args)
         return VException("Coordinate y smaller than 0.");
 
     try {
-        jpeg->SetBackground((unsigned char *)BufferData(data_buf), w, h);
+        jpeg->SetBackground((unsigned char *)Buffer::Data(data_buf), w, h);
     }
     catch (const char *err) {
         return VException(err);
@@ -421,7 +421,7 @@ DynamicJpegStack::EIO_JpegEncodeAfter(eio_req *req)
     }
     else {
         Buffer *buf = Buffer::New(enc_req->jpeg_len);
-        memcpy(BufferData(buf), enc_req->jpeg, enc_req->jpeg_len);
+        memcpy(Buffer::Data(buf), enc_req->jpeg, enc_req->jpeg_len);
         argv[0] = buf->handle_;
         argv[1] = jpeg->Dimensions();
         argv[2] = Undefined();

--- a/src/fixed_jpeg_stack.cpp
+++ b/src/fixed_jpeg_stack.cpp
@@ -43,7 +43,7 @@ FixedJpegStack::JpegEncodeSync()
         jpeg_encoder.encode();
         int jpeg_len = jpeg_encoder.get_jpeg_len();
         Buffer *retbuf = Buffer::New(jpeg_len);
-        memcpy(BufferData(retbuf), jpeg_encoder.get_jpeg(), jpeg_len);
+        memcpy(Buffer::Data(retbuf), jpeg_encoder.get_jpeg(), jpeg_len);
         return scope.Close(retbuf->handle_); 
     }
     catch (const char *err) {
@@ -218,7 +218,7 @@ FixedJpegStack::Push(const Arguments &args)
     if (y+h > jpeg->height) 
         return VException("Pushed fragment exceeds FixedJpegStack's height.");
 
-    jpeg->Push((unsigned char *)BufferData(data_buf), x, y, w, h);
+    jpeg->Push((unsigned char *)Buffer::Data(data_buf), x, y, w, h);
 
     return Undefined();
 }
@@ -287,7 +287,7 @@ FixedJpegStack::EIO_JpegEncodeAfter(eio_req *req)
     }
     else {
         Buffer *buf = Buffer::New(enc_req->jpeg_len);
-        memcpy(BufferData(buf), enc_req->jpeg, enc_req->jpeg_len);
+        memcpy(Buffer::Data(buf), enc_req->jpeg, enc_req->jpeg_len);
         argv[0] = buf->handle_;
         argv[1] = Undefined();
     }

--- a/src/fixed_jpeg_stack.cpp
+++ b/src/fixed_jpeg_stack.cpp
@@ -195,7 +195,7 @@ FixedJpegStack::Push(const Arguments &args)
         return VException("Fifth argument must be integer h.");
 
     FixedJpegStack *jpeg = ObjectWrap::Unwrap<FixedJpegStack>(args.This());
-    Buffer *data_buf = ObjectWrap::Unwrap<Buffer>(args[0]->ToObject());
+    Local<Object> data_buf = args[0]->ToObject();
     int x = args[1]->Int32Value();
     int y = args[2]->Int32Value();
     int w = args[3]->Int32Value();


### PR DESCRIPTION
i finally found the time to fix the the dynamic and fixed jpeg stacks.

all examples work again with node version 6.2.
they should work with node 6.6, but i can't test that as i have problems compiling that version.

thank you for `node-jpeg`!
