### PR TITLE
Added smoothing libjpeg option

### DIFF
--- a/src/jpeg.cpp
+++ b/src/jpeg.cpp
@@ -22,6 +22,7 @@ Jpeg::Initialize(v8::Handle<v8::Object> target)
     NODE_SET_PROTOTYPE_METHOD(t, "encode", JpegEncodeAsync);
     NODE_SET_PROTOTYPE_METHOD(t, "encodeSync", JpegEncodeSync);
     NODE_SET_PROTOTYPE_METHOD(t, "setQuality", SetQuality);
+    NODE_SET_PROTOTYPE_METHOD(t, "setSmoothing", SetSmoothing);
     target->Set(String::NewSymbol("Jpeg"), t->GetFunction());
 }
 
@@ -50,6 +51,12 @@ void
 Jpeg::SetQuality(int q)
 {
     jpeg_encoder.set_quality(q);
+}
+
+void
+Jpeg::SetSmoothing(int s)
+{
+    jpeg_encoder.set_smoothing(s);
 }
 
 Handle<Value>
@@ -133,6 +140,29 @@ Jpeg::SetQuality(const Arguments &args)
 
     Jpeg *jpeg = ObjectWrap::Unwrap<Jpeg>(args.This());
     jpeg->SetQuality(q);
+
+    return Undefined();
+}
+
+v8::Handle<v8::Value> Jpeg::SetSmoothing(const v8::Arguments &args)
+{
+    HandleScope scope;
+
+    if (args.Length() != 1)
+        return VException("One argument required - quality");
+
+    if (!args[0]->IsInt32())
+        return VException("First argument must be integer quality");
+
+    int s = args[0]->Int32Value();
+
+    if (s < 0)
+        return VException("Smoothing must be greater or equal to 0.");
+    if (s > 100)
+        return VException("Smoothing must be less than or equal to 100.");
+
+    Jpeg *jpeg = ObjectWrap::Unwrap<Jpeg>(args.This());
+    jpeg->SetSmoothing(s);
 
     return Undefined();
 }

--- a/src/jpeg.h
+++ b/src/jpeg.h
@@ -16,11 +16,13 @@ public:
     Jpeg(unsigned char *ddata, int wwidth, int hheight, buffer_type bbuf_type);
     v8::Handle<v8::Value> JpegEncodeSync();
     void SetQuality(int q);
+    void SetSmoothing(int s);
 
     static v8::Handle<v8::Value> New(const v8::Arguments &args);
     static v8::Handle<v8::Value> JpegEncodeSync(const v8::Arguments &args);
     static v8::Handle<v8::Value> JpegEncodeAsync(const v8::Arguments &args);
     static v8::Handle<v8::Value> SetQuality(const v8::Arguments &args);
+    static v8::Handle<v8::Value> SetSmoothing(const v8::Arguments &args);
 };
 
 #endif

--- a/src/jpeg_encoder.cpp
+++ b/src/jpeg_encoder.cpp
@@ -1,5 +1,4 @@
 #include "jpeg_encoder.h"
-#include "time.h"
 
 JpegEncoder::JpegEncoder(unsigned char *ddata, int wwidth, int hheight,
     int qquality, buffer_type bbuf_type)
@@ -114,10 +113,6 @@ jpeg_mem_dest (j_compress_ptr cinfo,
 void
 JpegEncoder::encode()
 {
-
-
-    clock_t t = clock();
-
     struct jpeg_compress_struct cinfo;
     struct jpeg_error_mgr jerr;
 
@@ -182,9 +177,6 @@ JpegEncoder::encode()
 
     if (buf_type == BUF_BGR || buf_type == BUF_RGBA || buf_type == BUF_BGRA)
         free(rgb_data);
-
-    t = clock() - t;
-    printf ("encode( took %d clicks (%f ms).\n",(int)t,((float)(t*1000))/CLOCKS_PER_SEC);
 }
 
 void

--- a/src/jpeg_encoder.cpp
+++ b/src/jpeg_encoder.cpp
@@ -3,7 +3,7 @@
 JpegEncoder::JpegEncoder(unsigned char *ddata, int wwidth, int hheight,
     int qquality, buffer_type bbuf_type)
     :
-    data(ddata), width(wwidth), height(hheight), quality(qquality),
+      data(ddata), width(wwidth), height(hheight), quality(qquality), smoothing(0),
     buf_type(bbuf_type),
     jpeg(NULL), jpeg_len(0),
     offset(0, 0, 0, 0) {}
@@ -134,6 +134,7 @@ JpegEncoder::encode()
 
     jpeg_set_defaults(&cinfo);
     jpeg_set_quality(&cinfo, quality, TRUE);
+    cinfo.smoothing_factor = smoothing;
     jpeg_start_compress(&cinfo, TRUE);
 
     unsigned char *rgb_data;
@@ -182,6 +183,11 @@ void
 JpegEncoder::set_quality(int q)
 {
     quality = q;
+}
+
+void JpegEncoder::set_smoothing(int ssmoothing)
+{
+    smoothing  = ssmoothing;
 }
 
 const unsigned char *

--- a/src/jpeg_encoder.cpp
+++ b/src/jpeg_encoder.cpp
@@ -1,4 +1,5 @@
 #include "jpeg_encoder.h"
+#include "time.h"
 
 JpegEncoder::JpegEncoder(unsigned char *ddata, int wwidth, int hheight,
     int qquality, buffer_type bbuf_type)
@@ -113,6 +114,10 @@ jpeg_mem_dest (j_compress_ptr cinfo,
 void
 JpegEncoder::encode()
 {
+
+
+    clock_t t = clock();
+
     struct jpeg_compress_struct cinfo;
     struct jpeg_error_mgr jerr;
 
@@ -177,6 +182,9 @@ JpegEncoder::encode()
 
     if (buf_type == BUF_BGR || buf_type == BUF_RGBA || buf_type == BUF_BGRA)
         free(rgb_data);
+
+    t = clock() - t;
+    printf ("encode( took %d clicks (%f ms).\n",(int)t,((float)(t*1000))/CLOCKS_PER_SEC);
 }
 
 void

--- a/src/jpeg_encoder.h
+++ b/src/jpeg_encoder.h
@@ -7,7 +7,7 @@
 #include "common.h"
 
 class JpegEncoder {
-    int width, height, quality;
+    int width, height, quality, smoothing;
     buffer_type buf_type;
     unsigned char *data;
 
@@ -23,6 +23,7 @@ public:
 
     void encode();
     void set_quality(int qquality);
+    void set_smoothing(int ssmoothing);
     const unsigned char *get_jpeg() const;
     unsigned int get_jpeg_len() const;
 


### PR DESCRIPTION
Added option to set smoothing_factor of libjpeg:
If non-zero, the input image is smoothed; the value should be 1 for
minimal smoothing to 100 for maximum smoothing.  The default is zero.
